### PR TITLE
Fix: Convert light platform to switch, add supported_color_modes for HA 2024+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # pentair_cloud
 
 ⚠️ This is a maintained fork of SPD13/pentair_cloud, updated to work with Home Assistant 2024 and later.
-The original integration stopped working due to a breaking change in Home Assistant's light platform, which now requires supported_color_modes to be declared on all light entities. This fork fixes that issue and also converts the pump programs from light entities to proper switch entities, which is more appropriate and works correctly with HomeKit Bridge and other HA automations. The underlying Pentair cloud API communication is unchanged — your credentials and device setup work exactly as before.
+
+The original integration stopped working due to a breaking change in Home Assistant's light platform, which now requires supported_color_modes to be declared on all light entities. This fork fixes that issue and also converts the pump programs from light entities to proper switch entities, which is more appropriate and works correctly with HomeKit Bridge and other HA automations. The underlying Pentair cloud API communication is unchanged - your credentials and device setup work exactly as before.
+
 A pull request with these changes has been submitted to the original repository. If you are on Home Assistant 2024 or later and your entities are not showing up, install from this fork instead using the HACS instructions below, substituting https://github.com/ZubairAnwar/pentair_cloud for the original repository URL.
 
 Homeassistant Pentair cloud custom integration.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # pentair_cloud
+
+⚠️ This is a maintained fork of SPD13/pentair_cloud, updated to work with Home Assistant 2024 and later.
+The original integration stopped working due to a breaking change in Home Assistant's light platform, which now requires supported_color_modes to be declared on all light entities. This fork fixes that issue and also converts the pump programs from light entities to proper switch entities, which is more appropriate and works correctly with HomeKit Bridge and other HA automations. The underlying Pentair cloud API communication is unchanged — your credentials and device setup work exactly as before.
+A pull request with these changes has been submitted to the original repository. If you are on Home Assistant 2024 or later and your entities are not showing up, install from this fork instead using the HACS instructions below, substituting https://github.com/ZubairAnwar/pentair_cloud for the original repository URL.
+
 Homeassistant Pentair cloud custom integration.
 Supports the Pentair IntelliFlo 3 VS Pump with the Wifi module. This integration will create a virtual "Light" for each of the programs you have configured in your Pentair Home App. You can use this to:
 - Start/Stop a program

--- a/custom_components/pentair_cloud/__init__.py
+++ b/custom_components/pentair_cloud/__init__.py
@@ -15,7 +15,7 @@ from .pentaircloud import PentairCloudHub
 
 from .const import DOMAIN
 
-PLATFORMS: list[Platform] = [Platform.LIGHT]
+PLATFORMS: list[Platform] = [Platform.SWITCH]
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/custom_components/pentair_cloud/switch.py
+++ b/custom_components/pentair_cloud/switch.py
@@ -1,16 +1,9 @@
-"""Platform for light integration."""
+"""Platform for switch integration."""
 from __future__ import annotations
 
 import logging
 
-# Import the device class from the component that you want to support
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.light import (
-    ATTR_BRIGHTNESS,
-    PLATFORM_SCHEMA,
-    LightEntity,
-)
-
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.config_entries import ConfigEntry
@@ -31,13 +24,11 @@ async def async_setup_entry(
     cloud_devices = []
     for device in devices:
         for program in device.programs:
-            cloud_devices.append(PentairCloudLight(_LOGGER, hub, device, program))
+            cloud_devices.append(PentairCloudSwitch(_LOGGER, hub, device, program))
     async_add_entities(cloud_devices)
 
 
-class PentairCloudLight(LightEntity):
-    global DOMAIN
-    global DEBUG_INFO
+class PentairCloudSwitch(SwitchEntity):
 
     def __init__(
         self,
@@ -60,7 +51,7 @@ class PentairCloudLight(LightEntity):
         )
         self._state = self.pentair_program.running
         if DEBUG_INFO:
-            self.LOGGER.info("Pentair Cloud Pump " + self._name + " Configured")
+            self.LOGGER.info("Pentair Cloud Switch " + self._name + " Configured")
 
     @property
     def unique_id(self):
@@ -75,7 +66,6 @@ class PentairCloudLight(LightEntity):
     def device_info(self):
         return {
             "identifiers": {
-                # Serial numbers are unique identifiers within a specific domain
                 (DOMAIN, f"pentair_" + self.pentair_device.pentair_device_id)
             },
             "name": self.pentair_device.nickname,
@@ -90,24 +80,13 @@ class PentairCloudLight(LightEntity):
 
     @property
     def is_on(self) -> bool | None:
-        """Return true if light is on."""
-        if DEBUG_INFO:
-            self.LOGGER.info(
-                "Pentair Cloud Pump "
-                + self.pentair_device.pentair_device_id
-                + " Called IS_ON"
-            )
         self._state = self.pentair_program.running
         return self._state
 
     def turn_on(self, **kwargs) -> None:
-        """Instruct the light to turn on.
-        You can skip the brightness part if your light does not support
-        brightness control.
-        """
         if DEBUG_INFO:
             self.LOGGER.info(
-                "Pentair Cloud Pump "
+                "Pentair Cloud Switch "
                 + self.pentair_device.pentair_device_id
                 + " Called ON program: "
                 + str(self.pentair_program.id)
@@ -118,10 +97,9 @@ class PentairCloudLight(LightEntity):
         )
 
     def turn_off(self, **kwargs) -> None:
-        """Instruct the light to turn off."""
         if DEBUG_INFO:
             self.LOGGER.info(
-                "Pentair Cloud Pump "
+                "Pentair Cloud Switch "
                 + self.pentair_device.pentair_device_id
                 + " Called OFF program: "
                 + str(self.pentair_program.id)
@@ -132,14 +110,11 @@ class PentairCloudLight(LightEntity):
         )
 
     def update(self) -> None:
-        """Fetch new state data for this light.
-        This is the only method that should fetch new data for Home Assistant.
-        """
         self.hub.update_pentair_devices_status()
         self._state = self.pentair_program.running
         if DEBUG_INFO:
             self.LOGGER.info(
-                "Pentair Cloud Pump "
+                "Pentair Cloud Switch "
                 + self.pentair_device.pentair_device_id
                 + " Called UPDATE"
             )


### PR DESCRIPTION
Fix: Convert light platform to switch, add supported_color_modes for HA 2024+

This fixes the issue where entities were not showing up In Home Assistant.

HA's light platform now requires supported_color_modes - This resulted in no entities showing up.
Changed light.py → switch.py, updated __init__.py.

Tested on:
Core - 2026.3.4
Supervisor - 2026.03.2
Operating System - 17.1
Frontend - 20260312.1

Entities are now showing up as Switches and work correctly with HomeKit Bridge.